### PR TITLE
Add missing optional field indicators

### DIFF
--- a/app/views/application/home.html.erb
+++ b/app/views/application/home.html.erb
@@ -55,7 +55,7 @@
 
       <div class="form-group">
         <label class="form-label" for="county">
-          County
+          County (optional)
         </label>
         <input class="form-control" id="county" type="text">
       </div>
@@ -69,7 +69,7 @@
 
       <div class="form-group">
         <label class="form-label" for="london-borough">
-          London borough
+          London borough (optional)
           <span class="form-hint">
             If applicable
           </span>
@@ -79,14 +79,14 @@
 
       <div class="form-group">
         <label class="form-label" for="website">
-          Website
+          Website (optional)
         </label>
         <input class="form-control" id="website" type="text">
       </div>
 
       <div class="form-group">
         <label class="form-label" for="telephone">
-          Telephone
+          Telephone (optional)
         </label>
         <input class="form-control" id="telephone" type="text">
       </div>
@@ -96,20 +96,23 @@
       <div class="form-group">
         <label class="form-label" for="leader-name">
           Name of the group leader or main contact in the group
+          <span class="form-hint">
+            This is the person the County Assessment Panel will contact to ask any questions or arrange a visit.
+          </span>
         </label>
         <input class="form-control" id="leader-name" type="text">
       </div>
 
       <div class="form-group">
         <label class="form-label" for="leader-position">
-          Position held in the group
+          Position held in the group (optional)
         </label>
         <input class="form-control" id="leader-position" type="text">
       </div>
 
       <div class="form-group">
         <label class="form-label" for="leader-involved">
-          How long has this person been involved in the group?
+          How long has this person been involved in the group? (optional)
         </label>
         <input class="form-control" id="leader-involved" type="text">
       </div>
@@ -146,7 +149,7 @@
 
       <div class="form-group">
         <label class="form-label" for="leader-county">
-          County
+          County (optional)
         </label>
         <input class="form-control" id="leader-county" type="text">
       </div>
@@ -160,7 +163,7 @@
 
       <div class="form-group">
         <label class="form-label" for="leader-london-borough">
-          London borough
+          London borough (optional)
           <span class="form-hint">
             If applicable
           </span>
@@ -194,7 +197,7 @@
       <div class="form-group">
         <label class="form-label" for="organisation-name">
           Is the group a branch of, or affiliated to, a larger or
-          national organisation? If yes, please give the name of the organisation
+          national organisation? If yes, please give the name of the organisation (optional)
         </label>
         <textarea class="form-control" id="organisation-name" cols="30" rows="5"></textarea>
       </div>
@@ -228,7 +231,7 @@
 
       <div class="form-group">
         <label class="form-label" for="group-beneficiaries">
-          Please explain where the group's beneficiaries (i.e. the people it helps) live
+          Please explain where the group's beneficiaries (i.e. the people it helps) live (optional)
         </label>
         <textarea class="form-control" id="group-beneficiaries" cols="30" rows="5"></textarea>
       </div>
@@ -422,7 +425,7 @@
 
       <div class="form-group">
         <label class="form-label" for="nominator-county">
-          County
+          County (optional)
         </label>
         <input class="form-control" id="nominator-county" type="text">
       </div>
@@ -436,7 +439,7 @@
 
       <div class="form-group">
         <label class="form-label" for="nominator-london-borough">
-          London borough
+          London borough (optional)
           <span class="form-hint">
             If applicable
           </span>
@@ -446,14 +449,14 @@
 
       <div class="form-group">
         <label class="form-label" for="nominator-telephone">
-          Telephone
+          Telephone (optional)
         </label>
         <input class="form-control" id="nominator-telephone" type="text">
       </div>
 
       <div class="form-group">
         <label class="form-label" for="nominator-mobile">
-          Mobile
+          Mobile (optional)
         </label>
         <input class="form-control" id="nominator-mobile" type="text">
       </div>


### PR DESCRIPTION
Based on the UX guidelines for GDS pages

> don't mark mandatory fields with asterisks
> if you do ask for optional information, mark the labels of optional fields with '(optional)'

I'm adding the missing optional field indicators.

Also I've added a missing hint from the original form.
